### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci.yml
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/francyfox/ash-qrb/security/code-scanning/2](https://github.com/francyfox/ash-qrb/security/code-scanning/2)

To address the issue, we will add a `permissions` block to the workflow. This block will be added at the root level to apply to all jobs unless overridden. Based on the workflow's operations, the minimal required permissions are likely `contents: read` for accessing the repository's code. Since the workflow does not appear to modify pull requests, issues, or other repository resources, no additional permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
